### PR TITLE
Fix build error using g++ 4.9.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CXX = g++
-CFLAGS = -Ilib -Itest -O2 -Wall -g
+CFLAGS = -std=c++11 -Ilib -Itest -O2 -Wall -g
 CXXFLAGS = $(CFLAGS)
 
 LIB_TARGET = lib/libbfp.a


### PR DESCRIPTION
Here's the error I was getting:

```
$ make
g++ -o main.o -Ilib -Itest -O2 -Wall -g -c main.cpp
main.cpp: In function 'int main(int, char**)':
main.cpp:7:5: warning: 'auto' changes meaning in C++11; please remove it [-Wc++0x-compat]
     auto p = Posit(5, 1);
     ^
main.cpp:7:10: error: 'p' does not name a type
     auto p = Posit(5, 1);
          ^
main.cpp:9:46: error: 'p' was not declared in this scope
     for (unsigned i = 0; i < (unsigned)(1 << p.nbits()); i++) {
                                              ^
make: *** [main.o] Error 1
```
